### PR TITLE
Add possibility of passing options to autoprefixer

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,9 @@ export default postcss.plugin('postcss-preset-env', opts => {
 			? 5
 		: parseInt(opts.stage) || 0
 	: 2;
+	const autoprefixerOptions = Object(opts).autoprefixerOptions
 
-	const stagedAutoprefixer = autoprefixer({ browsers });
+	const stagedAutoprefixer = autoprefixer(Object.assign({ browsers }, autoprefixerOptions));
 
 	// polyfillable features (those with an available postcss plugin)
 	const polyfillableFeatures = cssdb.concat(


### PR DESCRIPTION
I'm looking for a way of passing the "grid" option down to autoprefixer. This is the simplest solution i could come up with, but it might be better not to have a special case for autoprefixer and just set it using the features option?