### PR TITLE
update autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "autoprefixer": "^8.6.5",
+    "autoprefixer": "^9.1.3",
     "browserslist": "^3.2.8",
     "caniuse-lite": "^1.0.30000865",
     "cssdb": "^3.1.0",


### PR DESCRIPTION
First of all, thank you for this amazing package. It helps so much to not care (much) about old browsers and just write modern CSS.

While writing some Grid I realized that some code broke for me in IE11. The correct prefixes were there but IE ignored them. This was caused by autoprefixer nesting `@media` rules which IE11 doesn't support. The code was pretty similar to the problem in this issue https://github.com/postcss/autoprefixer/issues/1077. The bug was fixed in `autoprefixer@9.0.1`.

It would be amazing if `postcss-preset-env` could update it's autoprefixer version so others can more safely use Grid.