### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 language: node_js
 
 node_js:
+  - node
+  - 10
+  - 8
   - 6
 
 install:


### PR DESCRIPTION
We should test against all current LTS and stable branches of Node.js.