### PR TITLE
ci: test on Linux, macOS and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@
 
 language: node_js
 
+os:
+  - windows
+  - linux
+  - osx
+
 node_js:
   - 6
 


### PR DESCRIPTION
TravisCI has now Windows support and this replaces AppVeyor.

See https://blog.travis-ci.com/2018-10-11-windows-early-release