### PR TITLE
Convert autoprefixer "browsers" option to "overrideBrowserslist"

### DIFF
--- a/src/postcss.js
+++ b/src/postcss.js
@@ -23,7 +23,7 @@ export default postcss.plugin('postcss-preset-env', opts => {
 	const sharedOpts = initializeSharedOpts(Object(opts));
 	const stagedAutoprefixer = autoprefixerOptions === false
 		? () => {}
-	: autoprefixer(Object.assign({ browsers }, autoprefixerOptions));
+	: autoprefixer(Object.assign({ overrideBrowserslist: browsers }, autoprefixerOptions));
 
 	// polyfillable features (those with an available postcss plugin)
 	const polyfillableFeatures = cssdb.concat(


### PR DESCRIPTION
In response to https://github.com/csstools/postcss-preset-env/issues/133, reporting warnings coming from this package due to Autoprefixer deprecating the `browsers` option.

Users can get around the warning by using the `overrideBrowserslist` option directly, which it seems like many users are doing themselves (https://github.com/xing/hops/pull/898, https://github.com/moxystudio/postcss-preset-moxy/commit/cacb3a71075d4ab6c740217baf133931f4afc771, https://github.com/ipfs-shipyard/pm-idm/issues/206), but it's unlikely any user of this package will ever want the deprecated `browsers` option now so I think it's safe to proxy it for them.

Warning: I edited this directly on GitHub so it's untested, sorry about that! I'll get this repo set up later and run the tests to make sure I didn't break anything. 

Edit: Travis doesn't seem to like the merge commit that GitHub made (https://github.com/csstools/postcss-preset-env/commit/992e5b026dfd80c4da4a54c7cf3fd8457d8eda1c)