### PR TITLE
Update postcss-initial to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postcss-font-variant": "^4.0.0",
     "postcss-gap-properties": "^2.0.0",
     "postcss-image-set-function": "^3.0.1",
-    "postcss-initial": "^3.0.0",
+    "postcss-initial": "^3.0.1",
     "postcss-lab-function": "^2.0.1",
     "postcss-logical": "^3.0.0",
     "postcss-media-minmax": "^4.0.0",


### PR DESCRIPTION
postcss-initial@3.0.1 fixes a proto polution vulnerability in its
lodash.template dependency.


See https://github.com/maximkoretskiy/postcss-initial/compare/v3.0.1...master