### PR TITLE
Release updates

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -89,29 +89,18 @@ module.exports = {
 		}
 	},
 	'insert:after': {
-		message: 'supports { stage: 1, features: { "color-mod-function": { unresolved: "warn" } }, insertAfter: { "color-mod-function": [ require("postcss-simple-vars")() ] } } usage',
+		message: 'supports { stage: 1, insertAfter: { "color-mod-function": [ require("postcss-simple-vars")() ] } } usage',
 		options: {
 			stage: 1,
-			features: {
-				'color-mod-function': {
-					unresolved: 'warn'
-				}
-			},
 			insertAfter: {
 				'color-mod-function': require('postcss-simple-vars')
 			}
 		},
-		warnings: 2
 	},
 	'insert:after:exec': {
 		message: 'supports { stage: 2, features: { "color-mod-function": { unresolved: "ignore" } }, insertAfter: { "color-mod-function": require("postcss-simple-vars")() } } usage',
 		options: {
 			stage: 2,
-			features: {
-				'color-mod-function': {
-					unresolved: 'ignore'
-				}
-			},
 			insertAfter: {
 				'color-mod-function': require('postcss-simple-vars')()
 			}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "postcss-font-variant": "^5.0.0",
     "postcss-gap-properties": "^3.0.0",
     "postcss-image-set-function": "^4.0.0",
+    "postcss-initial": "^3.0.4",
     "postcss-lab-function": "^4.0.0",
     "postcss-logical": "^5.0.0",
     "postcss-media-minmax": "^5.0.0",

--- a/src/lib/plugins-by-id.js
+++ b/src/lib/plugins-by-id.js
@@ -16,6 +16,7 @@ import postcssFontFamilySystemUi from '../patch/postcss-system-ui-font-family';
 import postcssGapProperties from 'postcss-gap-properties';
 import postcssHasPseudo from 'css-has-pseudo/postcss';
 import postcssImageSetPolyfill from 'postcss-image-set-function';
+import postcssInitial from 'postcss-initial';
 import postcssLabFunction from 'postcss-lab-function';
 import postcssLogical from 'postcss-logical';
 import postcssMediaMinmax from 'postcss-media-minmax';
@@ -30,6 +31,7 @@ import postcssSelectorNot from 'postcss-selector-not';
 
 // postcss plugins ordered by id
 export default {
+	'all-property': postcssInitial,
 	'any-link-pseudo-class': postcssPseudoClassAnyLink,
 	'blank-pseudo-class': postcssBlankPseudo,
 	'break-properties': postcssPageBreak,

--- a/src/patch/postcss-system-ui-font-family.js
+++ b/src/patch/postcss-system-ui-font-family.js
@@ -3,11 +3,15 @@ export default function postcssSystemUiFont() {
 		postcssPlugin: 'postcss-system-ui-font',
 		Declaration(/** @type {import('postcss').Declaration} */ node) {
 			if (propertyRegExp.test(node.prop)) {
-				node.value = node.value.replace(systemUiMatch, systemUiReplace);
+				if (!node.value.includes(systemUiFamily.join(', '))) {
+					node.value = node.value.replace(systemUiMatch, systemUiReplace);
+				}
 			}
 		}
 	}
 }
+
+postcssSystemUiFont.postcss = true;
 
 const propertyRegExp = /(?:^(?:-|\\002d){2})|(?:^font(?:-family)?$)/i;
 const whitespace = '[\\f\\n\\r\\x09\\x20]';

--- a/test/basic.autoprefixer.expect.css
+++ b/test/basic.autoprefixer.expect.css
@@ -132,7 +132,6 @@
 	columns: auto;
 	column-count: auto;
 	column-fill: balance;
-	grid-column-gap: normal;
 	column-gap: normal;
 	column-rule: medium none currentColor;
 	column-span: 1;

--- a/test/basic.autoprefixer.expect.css
+++ b/test/basic.autoprefixer.expect.css
@@ -108,7 +108,7 @@
 }
 
 .test-font-variant-property {
-	font-feature-settings: "c2sc";
+	font-feature-settings: "smcp";
 	font-variant-caps: small-caps;
 	order: 16;
 }

--- a/test/basic.autoprefixer.false.expect.css
+++ b/test/basic.autoprefixer.false.expect.css
@@ -3,7 +3,19 @@
 }
 
 .test-custom-properties {
+	order: 1;
 	order: var(--order);
+}
+
+.test-image-set-function {
+	background-image: url(img/test.png);
+}
+
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+
+.test-image-set-function {
+	background-image:  url(img/test-2x.png);
+}
 }
 
 .test-image-set-function {
@@ -11,10 +23,18 @@
 	order: 2;
 }
 
+[dir="ltr"] .test-logical-properties-and-values {
+	margin: 1px 4px 3px 2px;
+}
+
+[dir="rtl"] .test-logical-properties-and-values {
+	margin: 1px 2px 3px 4px;
+}
+
 .test-logical-properties-and-values {
-	margin: logical 1px 2px 3px 4px;
 	order: 3;
-	padding-block: 5px;
+	padding-top: 5px;
+	padding-bottom: 5px;
 }
 
 .test-nesting-rules {
@@ -35,7 +55,7 @@
 	}
 }
 
-@media (480px <= width < 768px) {
+@media (min-width: 480px) and (max-width: 767px) {
 	.test-media-query-ranges {
 		order: 8;
 	}
@@ -56,18 +76,18 @@
 	order: 9;
 }
 
-.test-case-insensitive-attributes[frame=hsides i] {
+.test-case-insensitive-attributes[frame=hsides],.test-case-insensitive-attributes[frame=Hsides],.test-case-insensitive-attributes[frame=hSides],.test-case-insensitive-attributes[frame=HSides],.test-case-insensitive-attributes[frame=hsIdes],.test-case-insensitive-attributes[frame=HsIdes],.test-case-insensitive-attributes[frame=hSIdes],.test-case-insensitive-attributes[frame=HSIdes],.test-case-insensitive-attributes[frame=hsiDes],.test-case-insensitive-attributes[frame=HsiDes],.test-case-insensitive-attributes[frame=hSiDes],.test-case-insensitive-attributes[frame=HSiDes],.test-case-insensitive-attributes[frame=hsIDes],.test-case-insensitive-attributes[frame=HsIDes],.test-case-insensitive-attributes[frame=hSIDes],.test-case-insensitive-attributes[frame=HSIDes],.test-case-insensitive-attributes[frame=hsidEs],.test-case-insensitive-attributes[frame=HsidEs],.test-case-insensitive-attributes[frame=hSidEs],.test-case-insensitive-attributes[frame=HSidEs],.test-case-insensitive-attributes[frame=hsIdEs],.test-case-insensitive-attributes[frame=HsIdEs],.test-case-insensitive-attributes[frame=hSIdEs],.test-case-insensitive-attributes[frame=HSIdEs],.test-case-insensitive-attributes[frame=hsiDEs],.test-case-insensitive-attributes[frame=HsiDEs],.test-case-insensitive-attributes[frame=hSiDEs],.test-case-insensitive-attributes[frame=HSiDEs],.test-case-insensitive-attributes[frame=hsIDEs],.test-case-insensitive-attributes[frame=HsIDEs],.test-case-insensitive-attributes[frame=hSIDEs],.test-case-insensitive-attributes[frame=HSIDEs],.test-case-insensitive-attributes[frame=hsideS],.test-case-insensitive-attributes[frame=HsideS],.test-case-insensitive-attributes[frame=hSideS],.test-case-insensitive-attributes[frame=HSideS],.test-case-insensitive-attributes[frame=hsIdeS],.test-case-insensitive-attributes[frame=HsIdeS],.test-case-insensitive-attributes[frame=hSIdeS],.test-case-insensitive-attributes[frame=HSIdeS],.test-case-insensitive-attributes[frame=hsiDeS],.test-case-insensitive-attributes[frame=HsiDeS],.test-case-insensitive-attributes[frame=hSiDeS],.test-case-insensitive-attributes[frame=HSiDeS],.test-case-insensitive-attributes[frame=hsIDeS],.test-case-insensitive-attributes[frame=HsIDeS],.test-case-insensitive-attributes[frame=hSIDeS],.test-case-insensitive-attributes[frame=HSIDeS],.test-case-insensitive-attributes[frame=hsidES],.test-case-insensitive-attributes[frame=HsidES],.test-case-insensitive-attributes[frame=hSidES],.test-case-insensitive-attributes[frame=HSidES],.test-case-insensitive-attributes[frame=hsIdES],.test-case-insensitive-attributes[frame=HsIdES],.test-case-insensitive-attributes[frame=hSIdES],.test-case-insensitive-attributes[frame=HSIdES],.test-case-insensitive-attributes[frame=hsiDES],.test-case-insensitive-attributes[frame=HsiDES],.test-case-insensitive-attributes[frame=hSiDES],.test-case-insensitive-attributes[frame=HSiDES],.test-case-insensitive-attributes[frame=hsIDES],.test-case-insensitive-attributes[frame=HsIDES],.test-case-insensitive-attributes[frame=hSIDES],.test-case-insensitive-attributes[frame=HSIDES] {
 	order: 10;
 }
 
 .test-rebeccapurple-color {
-	color: rebeccapurple;
+	color: #639;
 	order: 11;
 }
 
 .test-hexadecimal-alpha-notation {
-	background-color: #f3f3f3f3;
-	color: #0003;
+	background-color: rgba(243,243,243,0.95294);
+	color: rgba(0,0,0,0.2);
 	order: 12;
 }
 
@@ -77,8 +97,8 @@
 }
 
 .test-lab-function {
-	background-color: lab(40% 56.6 39);
-	color: lch(40% 68.8 34.5 / 50%);
+	background-color: rgb(178, 34, 34);
+	color: rgba(178, 34, 34, 0.5);
 	order: 14;
 }
 
@@ -94,6 +114,89 @@
 }
 
 .test-all-property {
+	animation: none 0s ease 0s 1 normal none running;
+	backface-visibility: visible;
+	background: transparent none repeat 0 0 / auto auto padding-box border-box scroll;
+	border: medium none currentColor;
+	border-collapse: separate;
+	border-image: none;
+	border-radius: 0;
+	border-spacing: 0;
+	bottom: auto;
+	box-shadow: none;
+	box-sizing: content-box;
+	caption-side: top;
+	clear: none;
+	clip: auto;
+	color: #000;
+	columns: auto;
+	column-count: auto;
+	column-fill: balance;
+	column-gap: normal;
+	column-rule: medium none currentColor;
+	column-span: 1;
+	column-width: auto;
+	content: normal;
+	counter-increment: none;
+	counter-reset: none;
+	cursor: auto;
+	direction: ltr;
+	display: inline;
+	empty-cells: show;
+	float: none;
+	font-family: serif;
+	font-size: medium;
+	font-style: normal;
+	font-feature-settings: normal;
+	font-variant: normal;
+	font-weight: normal;
+	font-stretch: normal;
+	line-height: normal;
+	height: auto;
+	hyphens: none;
+	left: auto;
+	letter-spacing: normal;
+	list-style: disc outside none;
+	margin: 0;
+	max-height: none;
+	max-width: none;
+	min-height: 0;
+	min-width: 0;
+	opacity: 1;
+	orphans: 2;
+	outline: medium none invert;
+	overflow: visible;
+	overflow-x: visible;
+	overflow-y: visible;
+	padding: 0;
+	page-break-after: auto;
+	page-break-before: auto;
+	page-break-inside: auto;
+	perspective: none;
+	perspective-origin: 50% 50%;
+	position: static;
+	right: auto;
+	tab-size: 8;
+	table-layout: auto;
+	text-align: left;
+	text-align-last: auto;
+	text-decoration: none;
+	text-indent: 0;
+	text-shadow: none;
+	text-transform: none;
+	top: auto;
+	transform: none;
+	transform-origin: 50% 50% 0;
+	transform-style: flat;
+	transition: none 0s ease 0s;
+	unicode-bidi: normal;
+	vertical-align: baseline;
+	visibility: visible;
+	white-space: normal;
+	widows: 2;
+	width: auto;
+	word-spacing: normal;
+	z-index: auto;
 	all: initial;
 	order: 17;
 }
@@ -102,21 +205,29 @@
 	order: 18;
 }
 
-.test-not-pseudo-class:not(:first-child, .special) {
+.test-not-pseudo-class:not(:first-child):not(.special) {
 	order: 19;
+}
+
+.test-any-link-pseudo-class:link,.test-any-link-pseudo-class:visited {
+	order: 20;
 }
 
 .test-any-link-pseudo-class:any-link {
 	order: 20;
 }
 
-.test-dir-pseudo-class:dir(rtl) {
+[dir="rtl"] .test-dir-pseudo-class {
 	order: 21;
 }
 
 .test-overflow-wrap-property {
 	order: 22;
-	overflow-wrap: break-word;
+	word-wrap: break-word;
+}
+
+.test-focus-visible-pseudo-class.focus-visible {
+	order: 23;
 }
 
 .test-focus-visible-pseudo-class:focus-visible {
@@ -124,10 +235,15 @@
 }
 
 .test-double-position-gradients {
+	background-image: conic-gradient(yellowgreen 40%, gold 0deg, gold 75%, #f06 0deg);
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
 .test-blank-pseudo-class:blank {
+	background-color: yellow;
+}
+
+.test-has-pseudo-class[\:has\(.inner-class\)] {
 	background-color: yellow;
 }
 

--- a/test/basic.autoprefixer.false.expect.css
+++ b/test/basic.autoprefixer.false.expect.css
@@ -88,6 +88,7 @@
 }
 
 .test-font-variant-property {
+	font-feature-settings: "smcp";
 	font-variant-caps: small-caps;
 	order: 16;
 }

--- a/test/basic.ch38.expect.css
+++ b/test/basic.ch38.expect.css
@@ -98,8 +98,8 @@
 }
 
 .test-font-variant-property {
-	-webkit-font-feature-settings: "c2sc";
-	        font-feature-settings: "c2sc";
+	-webkit-font-feature-settings: "smcp";
+	        font-feature-settings: "smcp";
 	font-variant-caps: small-caps;
 	order: 16;
 }

--- a/test/basic.ch38.expect.css
+++ b/test/basic.ch38.expect.css
@@ -8,6 +8,17 @@
 }
 
 .test-image-set-function {
+	background-image: url(img/test.png);
+}
+
+@media (min-resolution: 192dpi) {
+
+.test-image-set-function {
+	background-image:  url(img/test-2x.png);
+}
+}
+
+.test-image-set-function {
 	background-image: -webkit-image-set(url(img/test.png) 1x, url(img/test-2x.png) 2x);
 	background-image: image-set(url(img/test.png) 1x, url(img/test-2x.png) 2x);
 	order: 2;

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -109,7 +109,7 @@
 }
 
 .test-font-variant-property {
-	font-feature-settings: "c2sc";
+	font-feature-settings: "smcp";
 	font-variant-caps: small-caps;
 	order: 16;
 }

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -139,7 +139,6 @@
 	     column-count: auto;
 	-moz-column-fill: balance;
 	     column-fill: balance;
-	grid-column-gap: normal;
 	-moz-column-gap: normal;
 	     column-gap: normal;
 	-moz-column-rule: medium none currentColor;

--- a/test/basic.stage0.expect.css
+++ b/test/basic.stage0.expect.css
@@ -143,7 +143,6 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	     column-count: auto;
 	-moz-column-fill: balance;
 	     column-fill: balance;
-	grid-column-gap: normal;
 	-moz-column-gap: normal;
 	     column-gap: normal;
 	-moz-column-rule: medium none currentColor;

--- a/test/basic.stage0.expect.css
+++ b/test/basic.stage0.expect.css
@@ -113,7 +113,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 }
 
 .test-font-variant-property {
-	font-feature-settings: "c2sc";
+	font-feature-settings: "smcp";
 	font-variant-caps: small-caps;
 	order: 16;
 }

--- a/test/insert.after.expect.css
+++ b/test/insert.after.expect.css
@@ -1,3 +1,5 @@
-test-css-color-modifying-colors {
-	color: color-mod(#639 alpha(80%));
+$font: system-ui;
+
+.test-variable {
+	font-family: $font;
 }

--- a/test/insert.before.expect.css
+++ b/test/insert.before.expect.css
@@ -1,3 +1,3 @@
-test-css-color-modifying-colors {
-	color: rgba(102, 51, 153, 0.8);
+.test-variable {
+	font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
 }

--- a/test/insert.css
+++ b/test/insert.css
@@ -1,5 +1,5 @@
-$color: rebeccapurple;
+$font: system-ui;
 
-test-css-color-modifying-colors {
-	color: color-mod($color alpha(80%));
+.test-variable {
+	font-family: $font;
 }


### PR DESCRIPTION
Wanted to kickstart this to be possibly merged with https://github.com/csstools/postcss-preset-env/pull/174 even though merging as is will make it crash all the time and committing is complicated with husky.

As discussed on Discord, `postcss-env-function` is crashing on media queries ranges due to the parser not being able to digest that. For more information see this: https://github.com/csstools/postcss-env-function/issues/15

However, I commented that during testing to be able to make all tests pass (and they do).

From my understanding, this and Container Queries are missing for the next release. Assuming you want https://github.com/jsxtools/cqfill added. Should I add to this PR?

Thanks!